### PR TITLE
fix(package): fixed private

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "bugs": {
     "url": "https://github.com/diplodoc-platform/diplodoc/issues"
   },
-  "private": true,
   "scripts": {
     "build": "run-p build:*",
     "build:js": "./esbuild/build.mjs",


### PR DESCRIPTION
fix for publish:
```
npm notice Publishing to https://registry.npmjs.org with tag latest and public access
npm ERR! code EPRIVATE
npm ERR! This package has been marked as private
npm ERR! Remove the 'private' field from the package.json to publish it.
```