### PR TITLE
feat(srcDoc): add sandbox option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ const {result} = await transform(
 
 The extension supports three different embedding strategies:
 
-- `srcdoc` — Uses an IFrame with `srcdoc` attribute to embed specified HTML. As such, the IFrame inherits parent's origin _and_ `Content-Security-Policy`. However, all CSS is isolated by default and there can never be any style leakage. Depending on the CSP used, this mode introduces a potential attack vector, since arbitrary JS code could have been allowed to be run by host's CSP. As such, use of sanitization is strongly preferred when using this mode (see below in [plugin documentation](#markdownit-transform-plugin)).
+- `srcdoc` — Uses an IFrame with `srcdoc` attribute to embed specified HTML. As such, the IFrame inherits parent's origin _and_ `Content-Security-Policy`. However, all CSS is isolated by default and there can never be any style leakage. Depending on the CSP used, this mode introduces a potential attack vector, since arbitrary JS code could have been allowed to be run by host's CSP. As such, use of sanitization is strongly preferred when using this mode (see below in [plugin documentation](#markdownit-transform-plugin)). You can use the `sandbox` option to set additional restrictions on the IFrame, including script execution.
 - `shadow` — Currently an experimental strategy that uses a ShadowRoot to embed content into the host page. Very similar in application and effects to `srcdoc`, but uses less runtime logic in browser, providing a more smooth experience (eliminates height resize jitters, etc.). Content sanitization is still strongly recommended. Styles declared inside of the ShadowRoot are isolated from the rest of the page as per ShadowDOM rules, and potential _inheritable_ global styles are isolated via `all: initial` at Shadow DOM boundary.
 - `isolated` — A strategy that uses a special IFrame that should be hosted on a separate origin such that Same-Origin-Policy (SOP) would not apply for this IFrame. By opting-out of SOP, any scripts that are being run inside of the IFrame cannot get access to parent's execution context, as well as its storage, cookies and more. Crucially, this mode also provides an option to use a less restrictive CSP for content inside trhe IFrame. As such, this strategy is ideal for widget embedding (or other types of potentially unsafe content).
 
@@ -167,6 +167,8 @@ Options:
 
 - `isolatedSandboxHost` - fully-qualified URL of the [IFrame runtime](#a-note-on-isolated-strategy-usage) used specifically by `isolated` mode. Has no effect when other modes are used. This can still be overriden by [`EmbedsConfig.isolatedSandboxHostURIOverride`](./src/types.ts#L8) via [`EmbeddedContentRootController.initialize`](./src/runtime/EmbeddedContentRootController.ts#L53) and [`EmbeddedContentRootController.setConfig`](./src/runtime/EmbeddedContentRootController.ts#L94).
 - `sanitize` - optional function that will be used to sanitize content in `srcdoc` and `shadow` modes if supplied.
+
+- `sandbox` - sandbox-mode, used by `srcdoc` embedding strategy (see iframe sandbox attribute). Disabled by default.
 
 ## React hook for smart control
 

--- a/example/README.md
+++ b/example/README.md
@@ -75,6 +75,19 @@ After html text
     <a href="#top">to top</a>
 :::
 
+## Variable height example
+
+::: html
+<details>
+    <summary>Expand content</summary>
+    <ol>
+        <li>one</li>
+        <li>two</li>
+        <li>three</li>
+    </ol>
+</details>
+:::
+
 ## Isolated IFrame (with script execution capabilities)
 
 Make sure to set the `embeddingMode` plugin option to `isolated`.

--- a/example/index.js
+++ b/example/index.js
@@ -21,12 +21,14 @@ import {promisify} from 'node:util';
                     </style>
                 `,
                 embeddingMode: 'srcdoc',
+                sandbox:
+                    'allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation allow-same-origin',
                 isolatedSandboxHost: 'http://localhost:5005/runtime.html',
             }),
         ],
     });
 
-    const html = `
+    const html = `<!DOCTYPE html>
 <html>
     <head>
         ${result.meta.script.map((scriptFile) => `<script src="${scriptFile}"></script>`).join('\n')}

--- a/src/iframe/NoScriptIFrameController.ts
+++ b/src/iframe/NoScriptIFrameController.ts
@@ -1,0 +1,102 @@
+import debounce from 'lodash.debounce';
+
+import {Disposable} from '../utils';
+
+const DEFAULT_RESIZE_DELAY = 150;
+
+type ResizeListener = (value: number) => void;
+
+export class NoScriptIFrameController extends Disposable {
+    private static observables = new Set<NoScriptIFrameController>();
+    private static resizeCheckerActive = false;
+
+    private static checkResize() {
+        if (!NoScriptIFrameController.resizeCheckerActive) {
+            return;
+        }
+
+        if (NoScriptIFrameController.observables.size === 0) {
+            NoScriptIFrameController.resizeCheckerActive = false;
+
+            return;
+        }
+
+        for (const observable of NoScriptIFrameController.observables) {
+            if (document.activeElement === observable.domContainer) {
+                observable.updateHeight();
+            }
+        }
+
+        requestAnimationFrame(NoScriptIFrameController.checkResize);
+    }
+
+    private static startResizeChecker() {
+        if (NoScriptIFrameController.resizeCheckerActive) {
+            return;
+        }
+
+        NoScriptIFrameController.resizeCheckerActive = true;
+        NoScriptIFrameController.checkResize();
+    }
+
+    private domContainer: HTMLIFrameElement;
+    private resizeObserver: ResizeObserver | undefined;
+    private lastHeight = 0;
+    private resizeListener: ResizeListener | undefined;
+
+    constructor(frame: HTMLIFrameElement) {
+        super();
+
+        this.domContainer = frame;
+    }
+
+    setResizeListener(listener: ResizeListener) {
+        this.resizeListener = listener;
+
+        NoScriptIFrameController.observables.add(this);
+        NoScriptIFrameController.startResizeChecker();
+
+        this.updateHeight();
+
+        const disconnectObserver = this.observeContainerResize();
+
+        return () => {
+            NoScriptIFrameController.observables.delete(this);
+            disconnectObserver();
+        };
+    }
+
+    updateHeight() {
+        const frameWindow = this.domContainer.contentWindow;
+
+        if (!frameWindow || !this.resizeListener) {
+            return;
+        }
+
+        const height = frameWindow.document.body.clientHeight;
+
+        if (height !== this.lastHeight) {
+            this.lastHeight = height;
+
+            this.resizeListener(height);
+        }
+    }
+
+    private observeContainerResize() {
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+        }
+
+        this.resizeObserver = new ResizeObserver(
+            debounce(() => {
+                this.updateHeight();
+            }, DEFAULT_RESIZE_DELAY),
+        );
+
+        this.resizeObserver.observe(this.domContainer);
+
+        return () => {
+            this.resizeObserver?.disconnect();
+        };
+    }
+}

--- a/src/plugin/renderers/defs.ts
+++ b/src/plugin/renderers/defs.ts
@@ -1,4 +1,5 @@
 export type RenderRuleFactoryOptions = {
     embedContentTransformFn?: (raw: string) => string;
     containerClassNames?: string;
+    sandbox?: boolean | string;
 };

--- a/src/plugin/renderers/srcdoc.ts
+++ b/src/plugin/renderers/srcdoc.ts
@@ -5,7 +5,11 @@ import {DATAATTR_SANDBOX_MODE} from '../../constants';
 import {RenderRuleFactoryOptions} from './defs';
 
 export const makeSrcdocModeEmbedRenderRule =
-    ({embedContentTransformFn, containerClassNames = ''}: RenderRuleFactoryOptions): RenderRule =>
+    ({
+        embedContentTransformFn,
+        containerClassNames = '',
+        sandbox,
+    }: RenderRuleFactoryOptions): RenderRule =>
     (tokens, idx, _opts, _env, self) => {
         const token = tokens[idx];
 
@@ -19,6 +23,10 @@ export const makeSrcdocModeEmbedRenderRule =
         token.attrSet('frameborder', '0');
         token.attrSet('style', 'width:100%');
         token.attrSet(DATAATTR_SANDBOX_MODE, 'srcdoc');
+
+        if (sandbox) {
+            token.attrSet('sandbox', sandbox === true ? '' : sandbox);
+        }
 
         return `<iframe ${self.renderAttrs(token)}></iframe>`;
     };

--- a/src/plugin/transform.ts
+++ b/src/plugin/transform.ts
@@ -27,6 +27,7 @@ export interface PluginOptions {
      */
     baseTarget?: BaseTarget;
     head?: string;
+    sandbox?: boolean | string;
 }
 
 type TransformOptions = {
@@ -105,6 +106,7 @@ export function transform({
     styles,
     baseTarget = '_parent',
     head: headContent,
+    sandbox,
 }: Partial<PluginOptions> = emptyOptions): MarkdownIt.PluginWithOptions<TransformOptions> {
     const plugin: MarkdownIt.PluginWithOptions<TransformOptions> = (md, options) => {
         const {output = '.'} = options || {};
@@ -113,6 +115,7 @@ export function transform({
 
         md.renderer.rules[SRCDOC_TOKEN_TYPE] = makeSrcdocModeEmbedRenderRule({
             containerClassNames: containerClasses,
+            sandbox,
             embedContentTransformFn: (raw) => {
                 const deprecatedHeadContent = concatStylesIncludeDirectives(
                     `<base target="${baseTarget}">`,
@@ -131,6 +134,7 @@ export function transform({
             containerClassNames: containerClasses,
             baseTarget,
             isolatedSandboxHost,
+            sandbox,
             embedContentTransformFn: (raw) => concatStylesIncludeDirectives(raw, styles),
         });
 

--- a/src/utils/isNoScriptIFrame.ts
+++ b/src/utils/isNoScriptIFrame.ts
@@ -1,0 +1,13 @@
+export function isNoScriptIFrame(frame: HTMLElement) {
+    if (!(frame instanceof HTMLIFrameElement)) {
+        return false;
+    }
+
+    for (const token of frame.sandbox) {
+        if (token === 'allow-scripts') {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/tests/src/__snapshots__/plugin.test.ts.snap
+++ b/tests/src/__snapshots__/plugin.test.ts.snap
@@ -25,6 +25,17 @@ exports[`HTML extension – plugin should generate html token 1`] = `
 ]
 `;
 
+exports[`HTML extension – plugin should render HTML in sandboxed iframe 1`] = `
+<iframe srcdoc="&lt;!DOCTYPE html&gt;&lt;html&gt;&lt;head&gt;&lt;base target=&quot;_parent&quot;&gt;&lt;/head&gt;&lt;body&gt;&lt;div class=&quot;html-div&quot;&gt;content&lt;/div&gt;
+&lt;/body&gt;&lt;/html&gt;"
+        frameborder="0"
+        style="width:100%"
+        data-yfm-sandbox-mode="srcdoc"
+        sandbox="allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation allow-same-origin"
+>
+</iframe>
+`;
+
 exports[`HTML extension – plugin should render html block 1`] = `
 <iframe srcdoc="&lt;!DOCTYPE html&gt;&lt;html&gt;&lt;head&gt;&lt;base target=&quot;_parent&quot;&gt;&lt;/head&gt;&lt;body&gt;&lt;div class=&quot;html-div&quot;&gt;content&lt;/div&gt;
 &lt;/body&gt;&lt;/html&gt;"

--- a/tests/src/plugin.test.ts
+++ b/tests/src/plugin.test.ts
@@ -44,4 +44,21 @@ describe('HTML extension – plugin', () => {
             ),
         ).toMatchSnapshot();
     });
+
+    it('should render HTML in sandboxed iframe', () => {
+        expect(
+            html(
+                dd`
+            :::html
+            <div class="html-div">content</div>
+            :::
+            `,
+                {
+                    embeddingMode: 'srcdoc',
+                    sandbox:
+                        'allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation allow-same-origin',
+                },
+            ),
+        ).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
Adds the `sandbox` option for the `srcdoc` mode, which allows you to enable additional security levels (the `sandbox` attribute on the iframe).

Fixes #59