### PR TITLE
feat: add ability to disable html block modes in runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Example with some styles:
 
 ```md
 ::: html
+
 <style>
   :root {
     --dark-bg-color: #000;
@@ -153,6 +154,16 @@ Or you can just include runtime's source code in your bundle.
 ```js
 import '@diplodoc/html-extension/runtime';
 ```
+
+To setup runtime config you can use function `setupRuntimeConfig(config: HTMLRuntimeConfig)`, where
+
+```ts
+type HTMLRuntimeConfig = {
+  disabledModes: ('shadow' | 'srcdoc' | 'isolated')[];
+};
+```
+
+Mods listed in the array `disabledModes` disables runtime controllers for this mods, so the elements on the page with `data-yfm-sandbox-mode={disabledMode}` will not be transformed by runtime.
 
 ## MarkdownIt transform plugin
 

--- a/esbuild/build.mjs
+++ b/esbuild/build.mjs
@@ -21,6 +21,7 @@ build({
     outfile: 'build/utils/index.js',
     minify: true,
     platform: 'browser',
+    format: 'cjs',
 });
 
 build({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 export const GLOBAL_SYMBOL = Symbol.for('diplodocHtml');
 export const QUEUE_SYMBOL = Symbol.for('queue');
+export const HTML_RUNTIME_CONFIG_SYMBOL = Symbol.for('htmlRuntimeConfig');
 
 export const DEFAULT_IFRAME_HEIGHT_PADDING = 34;
 

--- a/src/runtime/EmbeddedContentRootController.ts
+++ b/src/runtime/EmbeddedContentRootController.ts
@@ -65,6 +65,8 @@ export class EmbeddedContentRootController extends Disposable {
     initialize = async (configOverrideForThisInitCycle?: EmbedsConfig) => {
         const {disabledModes} = this.runtimeConfig;
 
+        // MAJOR: separate runtime controllers and chunks, so the consumer could
+        // import only one runtime mode: import('@diplodoc/html-extension/runtime/srcdoc');
         const embeds = Object.keys(embedFinders).reduce<HTMLElement[]>((result, current) => {
             const modeKey = current as EmbeddingMode;
 

--- a/src/runtime/EmbeddedContentRootController.ts
+++ b/src/runtime/EmbeddedContentRootController.ts
@@ -2,6 +2,7 @@ import {nanoid} from 'nanoid';
 
 import {EmbeddingMode, EmbedsConfig, HTMLRuntimeConfig} from '../types';
 import {Disposable} from '../utils';
+import {HTML_RUNTIME_CONFIG_SYMBOL} from '../constants';
 
 import {EmbeddedIFrameController} from './EmbeddedIFrameController';
 import {IEmbeddedContentController} from './IEmbeddedContentController';
@@ -9,7 +10,6 @@ import {ShadowRootController} from './ShadowRootController';
 import {SrcDocIFrameController} from './SrcDocIFrameController';
 
 import {IHTMLIFrameElementConfig} from '.';
-import { HTML_RUNTIME_CONFIG_SYMBOL } from '../constants';
 
 const findAllSrcDocEmbeds = (scope: ParentNode) =>
     scope.querySelectorAll<HTMLIFrameElement>('iframe[data-yfm-sandbox-mode=srcdoc]');
@@ -22,7 +22,7 @@ const embedFinders: Record<EmbeddingMode, (scope: ParentNode) => NodeListOf<HTML
     srcdoc: findAllSrcDocEmbeds,
     shadow: findAllShadowContainers,
     isolated: findAllIFrameEmbeds,
-}
+};
 
 const modeToController: Record<
     EmbeddingMode,
@@ -63,7 +63,7 @@ export class EmbeddedContentRootController extends Disposable {
     }
 
     initialize = async (configOverrideForThisInitCycle?: EmbedsConfig) => {
-        const { disabledModes } = this.runtimeConfig;
+        const {disabledModes} = this.runtimeConfig;
 
         const embeds = Object.keys(embedFinders).reduce<HTMLElement[]>((result, current) => {
             const modeKey = current as EmbeddingMode;
@@ -73,8 +73,7 @@ export class EmbeddedContentRootController extends Disposable {
             }
 
             return result;
-        }, [])
-
+        }, []);
 
         const dirtyEmbeds = embeds.filter(
             (el) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import {GLOBAL_SYMBOL, QUEUE_SYMBOL} from './constants';
+import {GLOBAL_SYMBOL, HTML_RUNTIME_CONFIG_SYMBOL, QUEUE_SYMBOL} from './constants';
 import {ScriptStore} from './common';
 
 export type ControllerCallback<T> = (controller: T) => void;
@@ -33,9 +33,14 @@ export type SanitizeConfig = {
     body?: Sanitize;
 };
 
+export type HTMLRuntimeConfig = {
+    disabledModes?: EmbeddingMode[];
+};
+
 declare global {
     interface Window {
         [GLOBAL_SYMBOL]: ScriptStore;
         [QUEUE_SYMBOL]: boolean;
+        [HTML_RUNTIME_CONFIG_SYMBOL]: HTMLRuntimeConfig,
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,6 @@ declare global {
     interface Window {
         [GLOBAL_SYMBOL]: ScriptStore;
         [QUEUE_SYMBOL]: boolean;
-        [HTML_RUNTIME_CONFIG_SYMBOL]: HTMLRuntimeConfig,
+        [HTML_RUNTIME_CONFIG_SYMBOL]: HTMLRuntimeConfig;
     }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './PromiseQueue';
 export * from './reconcile';
 export * from './timeout';
 export * from './Disposable';
+export * from './setupRuntimeConfig';

--- a/src/utils/setupRuntimeConfig.ts
+++ b/src/utils/setupRuntimeConfig.ts
@@ -1,0 +1,6 @@
+import { HTML_RUNTIME_CONFIG_SYMBOL } from "../constants";
+import { HTMLRuntimeConfig } from "../types";
+
+export const setupRuntimeConfig = (runtimeConfig: HTMLRuntimeConfig) => {
+    window[HTML_RUNTIME_CONFIG_SYMBOL] = runtimeConfig;
+}

--- a/src/utils/setupRuntimeConfig.ts
+++ b/src/utils/setupRuntimeConfig.ts
@@ -1,6 +1,6 @@
-import { HTML_RUNTIME_CONFIG_SYMBOL } from "../constants";
-import { HTMLRuntimeConfig } from "../types";
+import {HTML_RUNTIME_CONFIG_SYMBOL} from '../constants';
+import {HTMLRuntimeConfig} from '../types';
 
 export const setupRuntimeConfig = (runtimeConfig: HTMLRuntimeConfig) => {
     window[HTML_RUNTIME_CONFIG_SYMBOL] = runtimeConfig;
-}
+};


### PR DESCRIPTION
Add function `setupRuntimeConfig` that attached config for runtime to window
This function should be called before runtime initialization, if someone want to override default params
