### PR TITLE
fix(block): lheading on first line does not break directive block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
-        "@diplodoc/directive": "^0.3.0"
+        "@diplodoc/directive": "^0.3.3"
       },
       "devDependencies": {
         "@craftamap/esbuild-plugin-html": "^0.7.0",
@@ -1111,11 +1111,11 @@
       }
     },
     "node_modules/@diplodoc/directive": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@diplodoc/directive/-/directive-0.3.0.tgz",
-      "integrity": "sha512-1UD7UHthRqO0rju/XNAaKQIxSy/pa1giEMlARBZ7U4ZPi1QeTw+QNyXy1TwvnBb5hc6jAChTjfOxDwpct1AEdg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@diplodoc/directive/-/directive-0.3.3.tgz",
+      "integrity": "sha512-QojMfwlyjg0uhPd7I/roIkBYDDBsNkYmHPr7nzkHEGYC/nszJy/4NuWshzB10YW3CbWSO9BUwCk6XoZXgTrKZg==",
       "dependencies": {
-        "markdown-it-directive": "2.0.4"
+        "markdown-it-directive": "^2.0.6"
       }
     },
     "node_modules/@diplodoc/file-extension": {
@@ -10451,9 +10451,9 @@
       "dev": true
     },
     "node_modules/markdown-it-directive": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-directive/-/markdown-it-directive-2.0.4.tgz",
-      "integrity": "sha512-XtGbBcP0aoRgKiDIIsxvgSXZz3ptI5AOydLAfF+n/LRmdy4ROdHntboJMEg8Fd0B+SMtOynCpiDFDKboatPbMw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/markdown-it-directive/-/markdown-it-directive-2.0.6.tgz",
+      "integrity": "sha512-yTjIan0I3LRMooa9uPNTs1DlcNVx/NqRjrEd3eipe286I8t3z+xzSSstrQ3OGDmKJkDSjg0rShO1t3uMN04U3Q==",
       "peerDependencies": {
         "@types/markdown-it": "^12.0.0 || ^13.0.0",
         "markdown-it": "^12.0.0 || ^13.0.0"

--- a/package.json
+++ b/package.json
@@ -109,6 +109,6 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@diplodoc/directive": "^0.3.0"
+    "@diplodoc/directive": "^0.3.3"
   }
 }

--- a/tests/src/__snapshots__/plugin.test.ts.snap
+++ b/tests/src/__snapshots__/plugin.test.ts.snap
@@ -95,3 +95,25 @@ exports[`HTML extension – plugin should render html block 1`] = `
 >
 </iframe>
 `;
+
+exports[`HTML extension – plugin with special characters should render html block with dash in first line 1`] = `
+<iframe srcdoc="&lt;!DOCTYPE html&gt;&lt;html&gt;&lt;head&gt;&lt;base target=&quot;_parent&quot; /&gt;&lt;meta http-equiv=&quot;Content-Security-Policy&quot; content=&quot;script-src 'none'&quot; /&gt;&lt;/head&gt;&lt;body&gt;-
+&lt;div class=&quot;html-div&quot;&gt;content with dash in first line&lt;/div&gt;
+&lt;/body&gt;&lt;/html&gt;"
+        frameborder="0"
+        style="width:100%"
+        data-yfm-sandbox-mode="srcdoc"
+>
+</iframe>
+`;
+
+exports[`HTML extension – plugin with special characters should render html block with equals sign in first line 1`] = `
+<iframe srcdoc="&lt;!DOCTYPE html&gt;&lt;html&gt;&lt;head&gt;&lt;base target=&quot;_parent&quot; /&gt;&lt;meta http-equiv=&quot;Content-Security-Policy&quot; content=&quot;script-src 'none'&quot; /&gt;&lt;/head&gt;&lt;body&gt;=
+&lt;div class=&quot;html-div&quot;&gt;content with equals sign in first line&lt;/div&gt;
+&lt;/body&gt;&lt;/html&gt;"
+        frameborder="0"
+        style="width:100%"
+        data-yfm-sandbox-mode="srcdoc"
+>
+</iframe>
+`;

--- a/tests/src/plugin.test.ts
+++ b/tests/src/plugin.test.ts
@@ -100,6 +100,36 @@ describe('HTML extension – plugin', () => {
     });
 });
 
+describe('HTML extension – plugin with special characters', () => {
+    it('should render html block with dash in first line', () => {
+        expect(
+            html(
+                dd`
+            :::html
+            -
+            <div class="html-div">content with dash in first line</div>
+            :::
+            `,
+                {embeddingMode: 'srcdoc'},
+            ),
+        ).toMatchSnapshot();
+    });
+
+    it('should render html block with equals sign in first line', () => {
+        expect(
+            html(
+                dd`
+            :::html
+            =
+            <div class="html-div">content with equals sign in first line</div>
+            :::
+            `,
+                {embeddingMode: 'srcdoc'},
+            ),
+        ).toMatchSnapshot();
+    });
+});
+
 describe('HTML extension – plugin default sanitize', () => {
     it('should remove foreignObject tag', () => {
         expect(


### PR DESCRIPTION
When lheading ("-","=") was on first line of html block, it breakes this block

```
:::html
-
:::
```

was rendered to

`
<h2>:::html</h2>
<p>:::</p>
`