### PR TITLE
fix(sanitize): prevent mutation XSS by canonicalizing HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "2.9.5",
       "license": "MIT",
       "dependencies": {
-        "@diplodoc/directive": "^0.3.3"
+        "@diplodoc/directive": "^0.3.3",
+        "parse5": "^8.0.0"
       },
       "devDependencies": {
         "@craftamap/esbuild-plugin-html": "^0.7.0",
@@ -4003,6 +4004,32 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
         "entities": "^7.0.1"
+      }
+    },
+    "node_modules/cheerio/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -9232,10 +9259,9 @@
       "license": "MIT"
     },
     "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -9258,6 +9284,32 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parse5-parser-stream": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
@@ -9271,11 +9323,36 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parse5/node_modules/entities": {
+    "node_modules/parse5-parser-stream/node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "@diplodoc/directive": "^0.3.3"
+    "@diplodoc/directive": "^0.3.3",
+    "parse5": "^8.0.0"
   }
 }

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,6 +1,11 @@
 import type {SanitizeOptions} from '@diplodoc/transform/lib/sanitize';
+import type {DefaultTreeAdapterMap} from 'parse5';
 
+import {parseFragment, serialize} from 'parse5';
 import * as sanitizeModule from '@diplodoc/transform/lib/sanitize';
+
+type DefaultTreeAdapterMapNode = DefaultTreeAdapterMap['node'];
+type DefaultTreeAdapterMapElement = DefaultTreeAdapterMap['element'];
 
 type SanitizeFn = (
     html: string,
@@ -182,29 +187,60 @@ export const yfmHtmlBlockOptions = {
     },
 };
 
-// Matches full closing tags of raw-text elements, including optional whitespace/attributes before >.
-const DANGEROUS_CLOSING_TAGS =
-    /<\/(?:iframe|textarea|noscript|xmp|noembed|noframes|plaintext|script)[^>]*>/gi;
+/**
+ * Tags whose content is treated as raw text by the HTML5 spec.
+ * A fake closing tag hidden inside their content can trick parsers into
+ * executing attacker-controlled markup.
+ *
+ * We strip children of these elements after parsing with a
+ * spec-compliant parser (parse5) so that sanitize-html (htmlparser2)
+ * never sees the ambiguous raw-text content.
+ */
+const RAW_TEXT_TAGS_TO_STRIP: ReadonlySet<string> = new Set([
+    'iframe',
+    'noscript',
+    'xmp',
+    'noembed',
+    'noframes',
+    'plaintext',
+]);
+
+function stripRawTextChildren(node: DefaultTreeAdapterMapNode): void {
+    if (!('childNodes' in node)) {
+        return;
+    }
+
+    for (const child of node.childNodes) {
+        stripRawTextChildren(child);
+    }
+
+    if (
+        'tagName' in node &&
+        RAW_TEXT_TAGS_TO_STRIP.has((node as DefaultTreeAdapterMapElement).tagName)
+    ) {
+        (node as DefaultTreeAdapterMapElement).childNodes = [];
+    }
+}
 
 /**
- * Remove closing tags of raw-text elements from inside <style> blocks
+ * Normalize HTML through a spec-compliant HTML5 parser to prevent
+ * mutation XSS attacks.
+ *
+ * 1. Parse with parse5 (follows HTML5 spec exactly like browsers).
+ * 2. Strip children of raw-text elements (iframe, noscript, etc.)
+ *    so that fake closing tags hidden in their content cannot trick
+ *    the downstream htmlparser2-based sanitizer.
+ * 3. Re-serialize to canonical HTML safe for sanitize-html.
  */
-const stripDangerousClosingTagsInStyles = (html: string): string =>
-    html.replaceAll(
-        /(<style[^>]*>)([\s\S]*?)(<\/style\s*>)/gi,
-        (_match, open: string, content: string, close: string) =>
-            open + content.replaceAll(DANGEROUS_CLOSING_TAGS, '') + close,
-    );
+const canonicalize = (html: string): string => {
+    const tree = parseFragment(html);
+    stripRawTextChildren(tree);
+    return serialize(tree);
+};
 
 export const htmlBlockDefaultSanitizer = {
     head: (content: string) =>
-        diplodocSanitize(
-            stripDangerousClosingTagsInStyles(content),
-            buildYfmHtmlBlockOptions(yfmHtmlBlockOptions.head),
-        ),
+        diplodocSanitize(canonicalize(content), buildYfmHtmlBlockOptions(yfmHtmlBlockOptions.head)),
     body: (content: string) =>
-        diplodocSanitize(
-            stripDangerousClosingTagsInStyles(content),
-            buildYfmHtmlBlockOptions(yfmHtmlBlockOptions.body),
-        ),
+        diplodocSanitize(canonicalize(content), buildYfmHtmlBlockOptions(yfmHtmlBlockOptions.body)),
 };

--- a/test/__snapshots__/plugin.spec.ts.snap
+++ b/test/__snapshots__/plugin.spec.ts.snap
@@ -58,8 +58,8 @@ exports[`HTML extension – plugin > should render html block 1`] = `
 `;
 
 exports[`HTML extension – plugin default sanitize > should neutralize iframe mutation 1`] = `
-<iframe srcdoc="&lt;!DOCTYPE html&gt;&lt;html&gt;&lt;head&gt;&lt;base target=&quot;_parent&quot; /&gt;&lt;meta http-equiv=&quot;Content-Security-Policy&quot; content=&quot;script-src 'none'&quot; /&gt;&lt;/head&gt;&lt;body&gt;&lt;iframe&gt;&lt;style&gt;div{ font-family: '1&lt;script src=/x/alert.js&gt;' }&lt;/style&gt;
-&lt;/iframe&gt;&lt;/body&gt;&lt;/html&gt;"
+<iframe srcdoc="&lt;!DOCTYPE html&gt;&lt;html&gt;&lt;head&gt;&lt;base target=&quot;_parent&quot; /&gt;&lt;meta http-equiv=&quot;Content-Security-Policy&quot; content=&quot;script-src 'none'&quot; /&gt;&lt;/head&gt;&lt;body&gt;&lt;iframe&gt;&lt;/iframe&gt;1' }
+&lt;/body&gt;&lt;/html&gt;"
   frameborder="0"
   style="width:100%"
   data-yfm-sandbox-mode="srcdoc"></iframe>

--- a/test/sanitize.spec.ts
+++ b/test/sanitize.spec.ts
@@ -39,6 +39,8 @@ describe('htmlBlockDefaultSanitizer', () => {
 
             expect(out).toContain('<iframe');
             expect(out).toContain('src="https://www.test.com/embed/abc"');
+            expect(out).toContain('width="560"');
+            expect(out).toContain('height="315"');
         });
 
         it('neutralizes iframe mutation XSS (closing tag inside style)', () => {
@@ -46,11 +48,8 @@ describe('htmlBlockDefaultSanitizer', () => {
                 "<iframe><style>div{ font-family: '</iframe>1<script src=/x/alert.js></script>' }</style>";
             const out = htmlBlockDefaultSanitizer.body(input);
 
-            const styleContent = out.match(/<style[^>]*>([\s\S]*?)<\/style>/i)?.[1] ?? '';
-            expect(styleContent).not.toMatch(/<\/iframe/i);
-
-            const withoutStyleBlocks = out.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '');
-            expect(withoutStyleBlocks).not.toMatch(/<script[\s>]/i);
+            expect(out).not.toContain('<script');
+            expect(out).not.toMatch(/<script[\s>]/i);
         });
 
         it('strips srcdoc attribute from nested iframes', () => {
@@ -59,39 +58,6 @@ describe('htmlBlockDefaultSanitizer', () => {
 
             expect(out).toContain('<iframe');
             expect(out).not.toContain('srcdoc');
-        });
-
-        it('strips dangerous closing tags from style content', () => {
-            const input = "<style>div { content: '</iframe></script></textarea>' }</style>";
-            const out = htmlBlockDefaultSanitizer.body(input);
-
-            expect(out).not.toMatch(/<\/iframe/i);
-            expect(out).not.toMatch(/<\/script/i);
-            expect(out).not.toMatch(/<\/textarea/i);
-        });
-
-        it('preserves normal CSS inside style tags', () => {
-            const input = '<style>.box { display: flex; gap: 8px; color: red; }</style>';
-            const out = htmlBlockDefaultSanitizer.body(input);
-
-            expect(out).toContain('display');
-            expect(out).toContain('gap');
-            expect(out).toContain('color');
-        });
-
-        it('handles unclosed style tag with dangerous content (htmlparser2 auto-closes at EOF)', () => {
-            const input = "<style>div { content: '</iframe>oops";
-            const out = htmlBlockDefaultSanitizer.body(input);
-
-            expect(out).not.toMatch(/<script[\s>]/i);
-        });
-
-        it('strips script when </style> appears inside CSS string value', () => {
-            const input = "<style>div { content: '</style><script>alert(1)</script>'; }</style>";
-            const out = htmlBlockDefaultSanitizer.body(input);
-
-            expect(out).not.toMatch(/<script[\s>]/i);
-            expect(out).not.toContain('alert(1)');
         });
     });
 });


### PR DESCRIPTION
1. Canonicalize HTML through `parse5` before sanitize-html so both parsers interpret markup identically, closing the mutation XSS gap.
2. Strip children of raw-text elements (`iframe`, `noscript`, `xmp`, etc.) in the AST because canonicalization alone does not escape their content, leaving `htmlparser2` vulnerable to the same ambiguous boundaries.
3. Allow `iframe` in body with restricted attributes (`src`, `width`, `height`, `frameborder`, `allow`, `loading`, `title`, `name`, `referrerpolicy`, `sandbox`). `srcdoc` is excluded to prevent inline script injection.