### PR TITLE
fix(sanitize): strip dangerous closing tags inside style tag

### DIFF
--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -163,16 +163,48 @@ export const yfmHtmlBlockOptions = {
         cssWhiteList,
     },
     body: {
-        allowedTags: ['style'],
-        disallowedTags: ['iframe', 'frame', 'frameset', 'object', 'embed'],
-        allowedAttributes: {style: []},
+        allowedTags: ['style', 'iframe'],
+        disallowedTags: ['frame', 'frameset', 'object', 'embed'],
+        allowedAttributes: {
+            style: [],
+            iframe: [
+                'src',
+                'width',
+                'height',
+                'frameborder',
+                'loading',
+                'title',
+                'referrerpolicy',
+                'sandbox',
+            ],
+        },
         cssWhiteList,
     },
 };
 
+// Matches full closing tags of raw-text elements, including optional whitespace/attributes before >.
+const DANGEROUS_CLOSING_TAGS =
+    /<\/(?:iframe|textarea|noscript|xmp|noembed|noframes|plaintext|script)[^>]*>/gi;
+
+/**
+ * Remove closing tags of raw-text elements from inside <style> blocks
+ */
+const stripDangerousClosingTagsInStyles = (html: string): string =>
+    html.replaceAll(
+        /(<style[^>]*>)([\s\S]*?)(<\/style\s*>)/gi,
+        (_match, open: string, content: string, close: string) =>
+            open + content.replaceAll(DANGEROUS_CLOSING_TAGS, '') + close,
+    );
+
 export const htmlBlockDefaultSanitizer = {
     head: (content: string) =>
-        diplodocSanitize(content, buildYfmHtmlBlockOptions(yfmHtmlBlockOptions.head)),
+        diplodocSanitize(
+            stripDangerousClosingTagsInStyles(content),
+            buildYfmHtmlBlockOptions(yfmHtmlBlockOptions.head),
+        ),
     body: (content: string) =>
-        diplodocSanitize(content, buildYfmHtmlBlockOptions(yfmHtmlBlockOptions.body)),
+        diplodocSanitize(
+            stripDangerousClosingTagsInStyles(content),
+            buildYfmHtmlBlockOptions(yfmHtmlBlockOptions.body),
+        ),
 };

--- a/test/__snapshots__/plugin.spec.ts.snap
+++ b/test/__snapshots__/plugin.spec.ts.snap
@@ -58,8 +58,8 @@ exports[`HTML extension – plugin > should render html block 1`] = `
 `;
 
 exports[`HTML extension – plugin default sanitize > should neutralize iframe mutation 1`] = `
-<iframe srcdoc="&lt;!DOCTYPE html&gt;&lt;html&gt;&lt;head&gt;&lt;base target=&quot;_parent&quot; /&gt;&lt;meta http-equiv=&quot;Content-Security-Policy&quot; content=&quot;script-src 'none'&quot; /&gt;&lt;/head&gt;&lt;body&gt;&lt;style&gt;div{ font-family: '&lt;/iframe&gt;1&lt;script src=&quot;/x/alert.js&quot;&gt;&lt;/script&gt;' }
-&lt;/style&gt;&lt;/body&gt;&lt;/html&gt;"
+<iframe srcdoc="&lt;!DOCTYPE html&gt;&lt;html&gt;&lt;head&gt;&lt;base target=&quot;_parent&quot; /&gt;&lt;meta http-equiv=&quot;Content-Security-Policy&quot; content=&quot;script-src 'none'&quot; /&gt;&lt;/head&gt;&lt;body&gt;&lt;iframe&gt;&lt;style&gt;div{ font-family: '1&lt;script src=/x/alert.js&gt;' }&lt;/style&gt;
+&lt;/iframe&gt;&lt;/body&gt;&lt;/html&gt;"
   frameborder="0"
   style="width:100%"
   data-yfm-sandbox-mode="srcdoc"></iframe>

--- a/test/sanitize.spec.ts
+++ b/test/sanitize.spec.ts
@@ -31,5 +31,67 @@ describe('htmlBlockDefaultSanitizer', () => {
 
             expect(out).toMatch(/line-height:\s*22px/);
         });
+
+        it('preserves legitimate iframe with src', () => {
+            const input =
+                '<iframe src="https://www.test.com/embed/abc" width="560" height="315"></iframe>';
+            const out = htmlBlockDefaultSanitizer.body(input);
+
+            expect(out).toContain('<iframe');
+            expect(out).toContain('src="https://www.test.com/embed/abc"');
+        });
+
+        it('neutralizes iframe mutation XSS (closing tag inside style)', () => {
+            const input =
+                "<iframe><style>div{ font-family: '</iframe>1<script src=/x/alert.js></script>' }</style>";
+            const out = htmlBlockDefaultSanitizer.body(input);
+
+            const styleContent = out.match(/<style[^>]*>([\s\S]*?)<\/style>/i)?.[1] ?? '';
+            expect(styleContent).not.toMatch(/<\/iframe/i);
+
+            const withoutStyleBlocks = out.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '');
+            expect(withoutStyleBlocks).not.toMatch(/<script[\s>]/i);
+        });
+
+        it('strips srcdoc attribute from nested iframes', () => {
+            const input = '<iframe srcdoc="<script>alert(1)</script>" width="100"></iframe>';
+            const out = htmlBlockDefaultSanitizer.body(input);
+
+            expect(out).toContain('<iframe');
+            expect(out).not.toContain('srcdoc');
+        });
+
+        it('strips dangerous closing tags from style content', () => {
+            const input = "<style>div { content: '</iframe></script></textarea>' }</style>";
+            const out = htmlBlockDefaultSanitizer.body(input);
+
+            expect(out).not.toMatch(/<\/iframe/i);
+            expect(out).not.toMatch(/<\/script/i);
+            expect(out).not.toMatch(/<\/textarea/i);
+        });
+
+        it('preserves normal CSS inside style tags', () => {
+            const input = '<style>.box { display: flex; gap: 8px; color: red; }</style>';
+            const out = htmlBlockDefaultSanitizer.body(input);
+
+            expect(out).toContain('display');
+            expect(out).toContain('gap');
+            expect(out).toContain('color');
+        });
+
+        it('handles unclosed style tag with dangerous content (htmlparser2 auto-closes at EOF)', () => {
+            const input = "<style>div { content: '</iframe>oops";
+            const out = htmlBlockDefaultSanitizer.body(input);
+
+            expect(out).not.toMatch(/<script[\s>]/i);
+        });
+
+        it('strips script when </style> appears inside CSS string value', () => {
+            const input = "<style>div { content: '</style><script>alert(1)</script>'; }</style>";
+            const out = htmlBlockDefaultSanitizer.body(input);
+
+            expect(out).not.toMatch(/<script[\s>]/i);
+            expect(out).not.toContain('alert(1)');
+        });
     });
 });


### PR DESCRIPTION
- Added `<iframe>` to allowed body tags with safe attributes only (no `srcdoc`).
- Added regex-based pre-sanitization: inside `<style>` blocks, strip closing tags of raw-text elements (`</iframe>`, `</script>`, etc.).