### PR TITLE
feat(build): dual ESM/CJS package with conditional exports

### DIFF
--- a/.github/workflows/tests-built.yml
+++ b/.github/workflows/tests-built.yml
@@ -1,0 +1,45 @@
+# Local workflow — not from diplodoc/lint/scaffolding.
+# Runs the post-build regression suite (test/built-bundles.spec.ts) that
+# guards the published artefact contract (dual ESM/CJS, runtime IIFE,
+# __dirname banner, `exports` shape). This file should move into the
+# shared scaffolding template once the template grows a build-time test
+# step, after which this workflow can be removed.
+
+name: Built bundles
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+jobs:
+  test-built:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install latest npm (>= 11.5.1)
+        run: |
+          if [ "$(printf '%s\n' "11.5.1" "$(npm -v)" | sort -V | head -n1)" != "11.5.1" ]; then
+            npm install -g npm@^10 && npm install -g npm@latest
+          fi
+        shell: bash
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build and run post-build regression suite
+        run: npm run test:built

--- a/esbuild/build.mjs
+++ b/esbuild/build.mjs
@@ -2,6 +2,8 @@
 
 import {build, sassPlugin} from '@diplodoc/lint/esbuild';
 import {htmlPlugin} from '@craftamap/esbuild-plugin-html';
+import {mkdirSync, writeFileSync} from 'node:fs';
+import {resolve as resolvePath} from 'node:path';
 
 import pkg from '../package.json' with {type: 'json'};
 import tsConfig from '../tsconfig.json' with {type: 'json'};
@@ -14,62 +16,149 @@ const common = {
     tsconfig: './tsconfig.publish.json',
 };
 
-build({
-    ...common,
-    entryPoints: ['src/utils/index.ts'],
-    outfile: 'build/utils/index.js',
-    minify: true,
-    platform: 'browser',
-    format: 'cjs',
-});
-
-build({
-    ...common,
-    entryPoints: ['src/runtime/index.ts'],
-    outfile: 'build/runtime/index.js',
-    minify: true,
-    platform: 'browser',
-    plugins: [sassPlugin()],
-});
-
-build({
-    ...common,
-    entryPoints: ['src/react/index.ts'],
-    outfile: 'build/react/index.js',
-    platform: 'neutral',
-    external: ['react'],
-    target: 'es6',
-    format: 'cjs',
-});
-
-build({
-    ...common,
-    entryPoints: ['src/plugin/index.ts'],
-    outfile: 'build/plugin/index.js',
-    platform: 'node',
-    packages: 'external',
-    define: {
-        PACKAGE: JSON.stringify(pkg.name),
+const shimPlugin = (fmt) => ({
+    name: 'require-shim-switch',
+    setup(pluginBuild) {
+        pluginBuild.onResolve({filter: /^\.\/require-shim$/}, (args) => ({
+            path: resolvePath(args.resolveDir, `require-shim.${fmt}.ts`),
+        }));
     },
 });
 
-build({
-    ...common,
-    entryPoints: ['src/iframe/index.ts'],
-    sourcemap: false,
-    minify: true,
-    platform: 'browser',
-    metafile: true,
-    outdir: 'build/iframe/',
-    plugins: [
-        htmlPlugin({
-            files: [
-                {
-                    filename: 'runtime.html',
-                    entryPoints: ['src/iframe/index.ts'],
-                    inline: true,
-                },
-            ],
-        }),
-    ],
-});
+const pluginExternalCjs = ['@diplodoc/transform', 'markdown-it', '@diplodoc/directive'];
+
+/**
+ * @typedef {{
+ *   name: string,
+ *   entry: string,
+ *   platform: 'node' | 'browser' | 'neutral',
+ *   minify?: boolean,
+ *   target?: string,
+ *   external?: string[],
+ *   plugins?: import('esbuild').Plugin[],
+ *   define?: Record<string, string>,
+ * }} Entry
+ */
+
+/** @type {Entry[]} */
+const entries = [
+    {
+        name: 'plugin',
+        entry: 'src/plugin/index.ts',
+        platform: 'node',
+        define: {PACKAGE: JSON.stringify(pkg.name)},
+    },
+    {
+        name: 'react',
+        entry: 'src/react/index.ts',
+        platform: 'neutral',
+        external: ['react'],
+        target: 'es6',
+    },
+    {
+        name: 'utils',
+        entry: 'src/utils/index.ts',
+        platform: 'browser',
+        minify: true,
+    },
+];
+
+const builds = [];
+
+for (const e of entries) {
+    for (const fmt of ['esm', 'cjs']) {
+        /** @type {import('esbuild').BuildOptions} */
+        const opts = {
+            ...common,
+            entryPoints: [e.entry],
+            outfile: `build/${fmt}/${e.name}/index.js`,
+            format: fmt,
+            platform: e.platform,
+            plugins: [...(e.plugins ?? [])],
+        };
+
+        if (e.minify) opts.minify = true;
+        if (e.target) opts.target = e.target;
+        if (e.define) opts.define = e.define;
+
+        if (e.name === 'plugin') {
+            // Plugin is Node-only. Switch require-shim implementation per format.
+            opts.plugins.push(shimPlugin(fmt));
+
+            if (fmt === 'esm') {
+                // ESM: keep all deps external (parse5 imported natively as ESM).
+                opts.packages = 'external';
+                // __dirname is not defined in native ESM. Inject a banner
+                // that derives it from import.meta.url so Node-side code
+                // (copyRuntimeFiles) keeps working.
+                opts.banner = {
+                    js:
+                        "import { fileURLToPath as __efu } from 'node:url';" +
+                        "import { dirname as __edn } from 'node:path';" +
+                        'const __filename = __efu(import.meta.url);' +
+                        'const __dirname = __edn(__filename);',
+                };
+            } else {
+                // CJS: bundle parse5 (it is ESM-only, cannot be required).
+                // Peer deps stay external.
+                opts.external = pluginExternalCjs;
+            }
+        } else if (e.external) {
+            opts.external = e.external;
+        }
+
+        builds.push(build(opts));
+    }
+}
+
+// runtime — классический browser-script, грузится через <script src> (IIFE).
+// Отдельная сборка вне ESM/CJS-цикла: dual-формат для runtime некорректен —
+// его потребитель не Node-модуль, а тег <script> в iframe'е.
+builds.push(
+    build({
+        ...common,
+        entryPoints: ['src/runtime/index.ts'],
+        outfile: 'build/runtime/index.js',
+        format: 'iife',
+        platform: 'browser',
+        minify: true,
+        plugins: [sassPlugin()],
+    }),
+);
+
+// iframe — статичный HTML asset, собирается единожды.
+builds.push(
+    build({
+        ...common,
+        entryPoints: ['src/iframe/index.ts'],
+        sourcemap: false,
+        minify: true,
+        platform: 'browser',
+        metafile: true,
+        outdir: 'build/iframe/',
+        plugins: [
+            htmlPlugin({
+                files: [
+                    {
+                        filename: 'runtime.html',
+                        entryPoints: ['src/iframe/index.ts'],
+                        inline: true,
+                    },
+                ],
+            }),
+        ],
+    }),
+);
+
+await Promise.all(builds);
+
+mkdirSync('build/esm', {recursive: true});
+mkdirSync('build/cjs', {recursive: true});
+writeFileSync(
+    'build/esm/package.json',
+    JSON.stringify({type: 'module', sideEffects: false}, null, 2) + '\n',
+);
+writeFileSync(
+    'build/cjs/package.json',
+    JSON.stringify({type: 'commonjs', sideEffects: false}, null, 2) + '\n',
+);

--- a/esbuild/fix-esm-dts.mjs
+++ b/esbuild/fix-esm-dts.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+// Post-processes build/esm/**/*.d.ts so that imports carry an explicit `.js`
+// extension and directory imports resolve to `/index.js`. tsc with
+// `moduleResolution: "Bundler"` does not add extensions, but downstream TS
+// consumers using `NodeNext`/`Node16` require them on ESM-side declarations
+// (error TS2834 / TS2307).
+
+import {existsSync, readFileSync, readdirSync, statSync, writeFileSync} from 'node:fs';
+import {dirname, join} from 'node:path';
+
+const ROOT = 'build/esm';
+
+// Matches `from '<spec>'` / `from "<spec>"` (static imports / re-exports).
+const FROM_RE = /(\bfrom\s*)(['"])([^'"]+)\2/g;
+// Matches `import('<spec>')` / `import("<spec>")` (dynamic / inlined types).
+const DYN_RE = /(\bimport\s*\(\s*)(['"])([^'"]+)\2/g;
+
+// Deep-import specifiers that live inside packages WITHOUT an `exports` map,
+// so native ESM deep-import resolution requires an explicit `.js`. Keep this
+// list narrow — packages that DO ship `exports` (parse5, node:*) must not be
+// rewritten.
+const BARE_DEEP_IMPORT_WHITELIST = [/^@diplodoc\/transform\/lib\//];
+
+const hasExtension = (spec) => /\.(?:js|mjs|cjs|json|css)$/.test(spec);
+const isRelative = (spec) => spec.startsWith('./') || spec.startsWith('../');
+
+function resolveSpec(fileDir, spec) {
+    if (hasExtension(spec)) return spec;
+
+    if (isRelative(spec)) {
+        if (existsSync(join(fileDir, spec + '.d.ts'))) return spec + '.js';
+        if (existsSync(join(fileDir, spec, 'index.d.ts'))) return spec + '/index.js';
+        // Fallback: preserve legacy behaviour. Covers edge cases where the
+        // target file is emitted under a different name (rare in this repo).
+        return spec + '.js';
+    }
+
+    // Bare specifier. Only rewrite known deep-import shapes; root/package-name
+    // imports and packages with an `exports` map must be left untouched.
+    if (BARE_DEEP_IMPORT_WHITELIST.some((re) => re.test(spec))) {
+        return spec + '.js';
+    }
+
+    return spec;
+}
+
+function rewrite(src, fileDir) {
+    const replacer = (_m, lead, quote, spec) => {
+        const out = resolveSpec(fileDir, spec);
+        return `${lead}${quote}${out}${quote}`;
+    };
+    return src.replace(FROM_RE, replacer).replace(DYN_RE, replacer);
+}
+
+function walk(dir) {
+    for (const entry of readdirSync(dir)) {
+        const p = join(dir, entry);
+        const s = statSync(p);
+        if (s.isDirectory()) {
+            walk(p);
+        } else if (p.endsWith('.d.ts')) {
+            const before = readFileSync(p, 'utf8');
+            const after = rewrite(before, dirname(p));
+            if (after !== before) {
+                writeFileSync(p, after);
+            }
+        }
+    }
+}
+
+try {
+    statSync(ROOT);
+} catch {
+    console.error(`[fix-esm-dts] ${ROOT} does not exist — run build:declarations:esm first.`);
+    process.exit(1);
+}
+
+walk(ROOT);

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,11 +30,13 @@
         "markdown-it": "^13.0.1",
         "nanoid": "^5.0.7",
         "npm-run-all": "^4.1.5",
+        "rimraf": "^6.1.3",
         "ts-dedent": "^2.2.0",
         "typescript": "^5.3.3",
         "vitest": "^3.2.4"
       },
       "engines": {
+        "node": ">=18",
         "npm": ">=11.5.1"
       },
       "peerDependencies": {
@@ -6114,6 +6116,65 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/flat-cache/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/flat-cache/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/flat-cache/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/flat-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
@@ -6175,8 +6236,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -6867,7 +6927,6 @@
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -8608,11 +8667,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -9128,7 +9186,6 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
@@ -9376,7 +9433,6 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10112,66 +10168,100 @@
       "license": "MIT"
     },
     "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
-        "glob": "^7.1.3"
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
       },
       "bin": {
-        "rimraf": "bin.js"
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
-      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {
@@ -12873,8 +12963,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/write-file-atomic": {
       "version": "5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=18",
         "npm": ">=11.5.1"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,49 +2,69 @@
   "name": "@diplodoc/html-extension",
   "version": "2.9.6",
   "description": "HTML plugin for Diplodoc transformer and builder",
-  "main": "build/plugin/index.js",
-  "types": "build/plugin/index.d.ts",
+  "main": "build/cjs/plugin/index.js",
+  "module": "build/esm/plugin/index.js",
+  "types": "build/esm/plugin/index.d.ts",
   "engines": {
+    "node": ">=18",
     "npm": ">=11.5.1"
   },
   "typesVersions": {
     "*": {
       "index.d.ts": [
-        "./build/plugin/index.d.ts"
+        "./build/esm/plugin/index.d.ts"
       ],
       "iframe": [
         "./build/iframe/index.d.ts"
       ],
       "plugin": [
-        "./build/plugin/index.d.ts"
+        "./build/esm/plugin/index.d.ts"
       ],
       "react": [
-        "./build/react/index.d.ts"
+        "./build/esm/react/index.d.ts"
       ],
       "runtime": [
-        "./build/runtime/index.d.ts"
+        "./build/esm/runtime/index.d.ts"
       ],
       "utils": [
-        "./build/utils/index.d.ts"
+        "./build/esm/utils/index.d.ts"
       ]
     }
   },
   "exports": {
     ".": {
-      "types": "./build/plugin/index.d.ts",
-      "default": "./build/plugin/index.js"
+      "import": {
+        "types": "./build/esm/plugin/index.d.ts",
+        "default": "./build/esm/plugin/index.js"
+      },
+      "require": {
+        "types": "./build/cjs/plugin/index.d.ts",
+        "default": "./build/cjs/plugin/index.js"
+      }
     },
     "./runtime": {
-      "types": "./build/runtime/index.d.ts",
+      "types": "./build/esm/runtime/index.d.ts",
       "default": "./build/runtime/index.js"
     },
     "./react": {
-      "types": "./build/react/index.d.ts",
-      "default": "./build/react/index.js"
+      "import": {
+        "types": "./build/esm/react/index.d.ts",
+        "default": "./build/esm/react/index.js"
+      },
+      "require": {
+        "types": "./build/cjs/react/index.d.ts",
+        "default": "./build/cjs/react/index.js"
+      }
     },
     "./utils": {
-      "types": "./build/utils/index.d.ts",
-      "default": "./build/utils/index.js"
+      "import": {
+        "types": "./build/esm/utils/index.d.ts",
+        "default": "./build/esm/utils/index.js"
+      },
+      "require": {
+        "types": "./build/cjs/utils/index.d.ts",
+        "default": "./build/cjs/utils/index.js"
+      }
     },
     "./iframe": {
       "default": "./build/iframe/runtime.html"
@@ -59,13 +79,16 @@
     "url": "https://github.com/diplodoc-platform/diplodoc/issues"
   },
   "scripts": {
-    "build": "run-p build:*",
+    "clean": "rimraf build",
+    "build": "npm run clean && run-p \"build:**\"",
     "build:js": "node ./esbuild/build.mjs",
-    "build:declarations": "tsc --project tsconfig.publish.json --emitDeclarationOnly --outDir ./build",
-    "prepublishOnly": "npm run lint && npm run test && npm run build",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage",
+    "build:declarations:esm": "tsc --project tsconfig.esm.json --emitDeclarationOnly --outDir ./build/esm && node ./esbuild/fix-esm-dts.mjs",
+    "build:declarations:cjs": "tsc --project tsconfig.cjs.json --emitDeclarationOnly",
+    "prepublishOnly": "npm run lint && npm run test && npm run test:built",
+    "test": "vitest run --exclude test/built-bundles.spec.ts",
+    "test:watch": "vitest --exclude test/built-bundles.spec.ts",
+    "test:coverage": "vitest run --exclude test/built-bundles.spec.ts --coverage",
+    "test:built": "npm run build && vitest run test/built-bundles.spec.ts",
     "typecheck": "tsc -p . --noEmit",
     "lint": "lint update && lint",
     "lint:fix": "lint update && lint fix",
@@ -76,6 +99,9 @@
   "license": "MIT",
   "files": [
     "build"
+  ],
+  "sideEffects": [
+    "./build/runtime/index.js"
   ],
   "peerDependencies": {
     "@diplodoc/transform": "^4.0.0",
@@ -108,6 +134,7 @@
     "markdown-it": "^13.0.1",
     "nanoid": "^5.0.7",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.1.3",
     "ts-dedent": "^2.2.0",
     "typescript": "^5.3.3",
     "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "module": "build/esm/plugin/index.js",
   "types": "build/esm/plugin/index.d.ts",
   "engines": {
-    "node": ">=18",
     "npm": ">=11.5.1"
   },
   "typesVersions": {

--- a/src/plugin/copyRuntimeFiles.ts
+++ b/src/plugin/copyRuntimeFiles.ts
@@ -1,6 +1,6 @@
 import {dynrequire} from './utils';
 
-const PATH_TO_RUNTIME = '../runtime';
+const PATH_TO_RUNTIME = '../../runtime';
 
 interface CopyRuntimeFilesPaths {
     runtimeJsPath: string;

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,10 +1,43 @@
+import type {SanitizeOptions} from '@diplodoc/transform/lib/sanitize.js';
+import type {StylesObject} from '../types';
+import type {YfmHtmlBlockBuildOptions} from '../utils/sanitize';
+
+import {
+    buildYfmHtmlBlockOptions,
+    htmlBlockDefaultSanitizer,
+    yfmHtmlBlockOptions,
+} from '../utils/sanitize';
+
+import {transform} from './transform';
+import {getStyles} from './utils';
+
 export type {BaseTarget, StylesObject, HTMLRuntimeConfig, EmbeddingMode} from '../types';
 export type {PluginOptions} from './transform';
-export {getStyles} from './utils';
-export {transform} from './transform';
 export type {YfmHtmlBlockBuildOptions} from '../utils/sanitize';
 export {
     buildYfmHtmlBlockOptions,
-    yfmHtmlBlockOptions,
+    getStyles,
     htmlBlockDefaultSanitizer,
-} from '../utils/sanitize';
+    transform,
+    yfmHtmlBlockOptions,
+};
+
+// Explicitly typed to stop tsc from inlining the default shape via
+// `import(".").Foo` — self-references do not resolve under NodeNext.
+export interface HtmlExtensionNamespace {
+    buildYfmHtmlBlockOptions: (options: YfmHtmlBlockBuildOptions) => SanitizeOptions;
+    getStyles: (styles: StylesObject) => string;
+    htmlBlockDefaultSanitizer: typeof htmlBlockDefaultSanitizer;
+    transform: typeof transform;
+    yfmHtmlBlockOptions: typeof yfmHtmlBlockOptions;
+}
+
+const htmlExtension: HtmlExtensionNamespace = {
+    buildYfmHtmlBlockOptions,
+    getStyles,
+    htmlBlockDefaultSanitizer,
+    transform,
+    yfmHtmlBlockOptions,
+};
+
+export default htmlExtension;

--- a/src/plugin/require-shim.cjs.ts
+++ b/src/plugin/require-shim.cjs.ts
@@ -1,0 +1,5 @@
+import type {DynRequire} from './require-shim';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+/* v8 ignore next */
+export const dynrequire: DynRequire = require as DynRequire;

--- a/src/plugin/require-shim.esm.ts
+++ b/src/plugin/require-shim.esm.ts
@@ -1,0 +1,7 @@
+import type {DynRequire} from './require-shim';
+
+/* v8 ignore next */
+import {createRequire} from 'node:module';
+
+/* v8 ignore next */
+export const dynrequire: DynRequire = createRequire(import.meta.url) as DynRequire;

--- a/src/plugin/require-shim.ts
+++ b/src/plugin/require-shim.ts
@@ -1,0 +1,17 @@
+// Alias-only stub. The esbuild `shimPlugin` (see esbuild/build.mjs) rewrites
+// imports of './require-shim' to './require-shim.{esm,cjs}.ts' at build time.
+//
+// ESM target -> require-shim.esm.ts (createRequire(import.meta.url))
+// CJS target -> require-shim.cjs.ts (native require)
+//
+// Source-level execution of plugin code that calls dynrequire() is NOT
+// supported: run the built bundle (build/{esm,cjs}/plugin/index.js) instead.
+//
+// `DynRequire` avoids leaking the ambient `NodeRequire` type into the
+// published `.d.ts`, which would force consumers to have `@types/node`.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type DynRequire = <T = any>(spec: string) => T;
+
+export const dynrequire: DynRequire = (() => {
+    throw new Error('require-shim: alias was not applied during build');
+}) as unknown as DynRequire;

--- a/src/plugin/utils.ts
+++ b/src/plugin/utils.ts
@@ -15,14 +15,7 @@ export function addHiddenProperty<
     return box as B & {[P in F]: V};
 }
 
-/*
- * Runtime require hidden for builders.
- * Used for nodejs api
- */
-export function dynrequire(module: string) {
-    // eslint-disable-next-line no-eval
-    return eval(`require('${module}')`);
-}
+export {dynrequire} from './require-shim';
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 const hasOwnProperty = (obj: Object, prop: string) =>

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -15,8 +15,16 @@ if (isBrowser()) {
     }
 }
 
+/**
+ * @deprecated `@diplodoc/html-extension/runtime` is a `<script src>` IIFE
+ * bundle, not an importable ESM/CJS module. These re-exports describe the
+ * in-bundle controller that attaches itself to the browser globals — they
+ * are not meant to be imported programmatically and will be removed in the
+ * next major. For Node/SSR work, use `@diplodoc/html-extension` (plugin entry).
+ */
 export {EmbeddedContentRootController as HtmlController};
 
+/** @deprecated see `HtmlController` above */
 export type {
     ControllerCallback,
     EmbedsConfig as IHTMLIFrameElementConfig,

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,8 +1,11 @@
-import type {SanitizeOptions} from '@diplodoc/transform/lib/sanitize';
+// The `.js` extension is required for native-ESM deep-import resolution:
+// Node ESM rejects extension-less subpath imports for packages that do not
+// declare an `exports` map (which is the case for @diplodoc/transform).
+import type {SanitizeOptions} from '@diplodoc/transform/lib/sanitize.js';
 import type {DefaultTreeAdapterMap} from 'parse5';
 
 import {parseFragment, serialize} from 'parse5';
-import * as sanitizeModule from '@diplodoc/transform/lib/sanitize';
+import * as sanitizeModule from '@diplodoc/transform/lib/sanitize.js';
 
 type DefaultTreeAdapterMapNode = DefaultTreeAdapterMap['node'];
 type DefaultTreeAdapterMapElement = DefaultTreeAdapterMap['element'];
@@ -31,7 +34,6 @@ const getSanitizeFunction = (): SanitizeFn => {
     return sanitize instanceof Function ? sanitize : sanitizeAll;
 };
 
-// MAJOR: use `import {sanitize} from '@diplodoc/transform/lib/sanitize.js'`
 const diplodocSanitize = getSanitizeFunction();
 
 const {defaultOptions: sanitizeDefaultOptions} = sanitizeModule;
@@ -222,7 +224,7 @@ function stripRawTextChildren(node: DefaultTreeAdapterMapNode): void {
     }
 }
 
-/**
+/*
  * Normalize HTML through a spec-compliant HTML5 parser to prevent
  * mutation XSS attacks.
  *

--- a/test/built-bundles.spec.ts
+++ b/test/built-bundles.spec.ts
@@ -354,10 +354,6 @@ describe('built bundles (post-build regression guard)', () => {
             expect(pkg.exports['./runtime'].types).toBe('./build/esm/runtime/index.d.ts');
             expect(pkg.typesVersions?.['*']?.runtime).toEqual(['./build/esm/runtime/index.d.ts']);
         });
-
-        it('declares engines.node baseline for ESM support', () => {
-            expect(pkg.engines?.node).toBeDefined();
-        });
     });
 
     describe('per-format virtual package.json', () => {

--- a/test/built-bundles.spec.ts
+++ b/test/built-bundles.spec.ts
@@ -1,0 +1,407 @@
+import {existsSync, mkdtempSync, readFileSync, readdirSync, statSync} from 'node:fs';
+import {createRequire} from 'node:module';
+import {tmpdir} from 'node:os';
+import {dirname, join, relative, resolve} from 'node:path';
+import {pathToFileURL} from 'node:url';
+import vm from 'node:vm';
+import {beforeAll, describe, expect, it} from 'vitest';
+
+const root = resolve(__dirname, '..');
+const esmRoot = resolve(root, 'build/esm');
+const cjsRoot = resolve(root, 'build/cjs');
+const esmEntry = resolve(root, 'build/esm/plugin/index.js');
+const cjsEntry = resolve(root, 'build/cjs/plugin/index.js');
+const esmReactEntry = resolve(root, 'build/esm/react/index.js');
+const cjsReactEntry = resolve(root, 'build/cjs/react/index.js');
+const esmUtilsEntry = resolve(root, 'build/esm/utils/index.js');
+const cjsUtilsEntry = resolve(root, 'build/cjs/utils/index.js');
+const esmPluginDts = resolve(root, 'build/esm/plugin/index.d.ts');
+const runtimeBundle = resolve(root, 'build/runtime/index.js');
+const pkgPath = resolve(root, 'package.json');
+
+const req = createRequire(import.meta.url);
+
+// Expected public names for plugin entry (keep in sync with src/plugin/index.ts).
+const PLUGIN_EXPECTED_KEYS = [
+    'buildYfmHtmlBlockOptions',
+    'getStyles',
+    'htmlBlockDefaultSanitizer',
+    'transform',
+    'yfmHtmlBlockOptions',
+].sort();
+
+const REACT_EXPECTED_NAMES = [
+    'useDiplodocEmbeddedContentController',
+    'useDiplodocEmbeddedContent',
+    'EmbeddedContentRuntime',
+];
+
+const UTILS_EXPECTED_NAMES = ['TaskQueue', 'setupRuntimeConfig', 'timeout', 'Disposable'];
+
+// Bare specifiers that ship without an `exports` map, so native ESM deep-import
+// resolution requires an explicit `.js`. Keep in sync with
+// BARE_DEEP_IMPORT_WHITELIST in esbuild/fix-esm-dts.mjs.
+const BARE_DEEP_IMPORT_WHITELIST = [/^@diplodoc\/transform\/lib\//];
+
+const KNOWN_EXTENSIONS = /\.(?:js|mjs|cjs|json|css)$/;
+
+function listDts(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir)) {
+        const p = join(dir, entry);
+        const s = statSync(p);
+        if (s.isDirectory()) out.push(...listDts(p));
+        else if (p.endsWith('.d.ts')) out.push(p);
+    }
+    return out;
+}
+
+interface Offender {
+    file: string;
+    spec: string;
+    reason: string;
+}
+
+function collectDtsImportOffenders(dtsFiles: string[]): Offender[] {
+    const offenders: Offender[] = [];
+    // Matches `from '<spec>'`, `from "<spec>"`, `import('<spec>')`, `import("<spec>")`.
+    const re = /(?:\bfrom\s*|\bimport\s*\(\s*)(['"])([^'"]+)\1/g;
+
+    for (const file of dtsFiles) {
+        const src = readFileSync(file, 'utf8');
+        const fileDir = dirname(file);
+
+        for (const m of src.matchAll(re)) {
+            const spec = m[2];
+
+            if (spec === '.' || spec === '..') {
+                offenders.push({
+                    file,
+                    spec,
+                    reason: 'self-reference does not resolve under NodeNext',
+                });
+                continue;
+            }
+
+            const isRelative = spec.startsWith('./') || spec.startsWith('../');
+
+            if (isRelative) {
+                if (!KNOWN_EXTENSIONS.test(spec)) {
+                    offenders.push({file, spec, reason: 'relative spec missing .js extension'});
+                    continue;
+                }
+                // Strip known extension and resolve physically. `.js` -> `.d.ts`.
+                const withoutExt = spec.replace(/\.(?:js|mjs|cjs)$/, '');
+                const asFile = join(fileDir, withoutExt + '.d.ts');
+                if (!existsSync(asFile) && !spec.endsWith('.json') && !spec.endsWith('.css')) {
+                    offenders.push({
+                        file,
+                        spec,
+                        reason: `resolved .d.ts does not exist (${relative(root, asFile)})`,
+                    });
+                }
+            } else if (BARE_DEEP_IMPORT_WHITELIST.some((w) => w.test(spec))) {
+                if (!KNOWN_EXTENSIONS.test(spec)) {
+                    offenders.push({
+                        file,
+                        spec,
+                        reason: 'whitelisted deep-import bare spec missing .js extension',
+                    });
+                }
+            }
+            // Other bare specifiers: skip. Packages with their own `exports` map
+            // (parse5, node:*, markdown-it with types) don't need `.js`.
+        }
+    }
+    return offenders;
+}
+
+describe('built bundles (post-build regression guard)', () => {
+    beforeAll(() => {
+        for (const p of [
+            esmEntry,
+            cjsEntry,
+            esmReactEntry,
+            cjsReactEntry,
+            esmUtilsEntry,
+            cjsUtilsEntry,
+            esmPluginDts,
+            runtimeBundle,
+        ]) {
+            if (!existsSync(p)) {
+                throw new Error(
+                    `Built artefact missing: ${p}. Run \`npm run build\` before this suite.`,
+                );
+            }
+        }
+    });
+
+    describe('plugin ESM bundle', () => {
+        it('exposes named + default exports, default mirrors namespace', async () => {
+            const mod = await import(pathToFileURL(esmEntry).href);
+
+            expect(typeof mod.transform).toBe('function');
+            expect(typeof mod.getStyles).toBe('function');
+            expect(mod.default).toBeDefined();
+            expect(mod.default.transform).toBe(mod.transform);
+            expect(mod.default.getStyles).toBe(mod.getStyles);
+        });
+
+        it('default object keys match the full named-export surface', async () => {
+            const mod = await import(pathToFileURL(esmEntry).href);
+            const named = Object.keys(mod)
+                .filter((k) => k !== 'default')
+                .sort();
+            const defaultKeys = Object.keys(mod.default).sort();
+
+            expect(named).toEqual(PLUGIN_EXPECTED_KEYS);
+            expect(defaultKeys).toEqual(PLUGIN_EXPECTED_KEYS);
+        });
+
+        it('does not leak bare __dirname after esbuild banner (regression #2)', () => {
+            const src = readFileSync(esmEntry, 'utf8');
+            const bannerMatch = /const __dirname = __edn\(__filename\);/.test(src);
+            expect(bannerMatch, 'banner must define __dirname').toBe(true);
+        });
+    });
+
+    describe('plugin CJS bundle', () => {
+        it('exposes named + default exports via require()', () => {
+            const cjs = req(cjsEntry);
+
+            expect(typeof cjs.transform).toBe('function');
+            expect(cjs.default).toBeDefined();
+            expect(cjs.default.transform).toBe(cjs.transform);
+        });
+
+        it('default object keys match the full named-export surface', () => {
+            const cjs = req(cjsEntry);
+            const named = Object.keys(cjs)
+                .filter((k) => k !== 'default' && k !== '__esModule')
+                .sort();
+            const defaultKeys = Object.keys(cjs.default).sort();
+
+            expect(named).toEqual(PLUGIN_EXPECTED_KEYS);
+            expect(defaultKeys).toEqual(PLUGIN_EXPECTED_KEYS);
+        });
+    });
+
+    describe('ESM .d.ts contract (NodeNext-compatible)', () => {
+        // Node ESM + moduleResolution: NodeNext requires explicit `.js` on
+        // relative imports, `/index.js` on directory imports, and refuses
+        // self-references (`import(".")`). tsc with moduleResolution: Bundler
+        // does not produce these — esbuild/fix-esm-dts.mjs rewrites post-build.
+        //
+        // This guard covers the WHOLE build/esm tree, not just plugin/, and
+        // matches both `from '…'` and `import('…')` (inlined type expressions).
+        it('every .d.ts under build/esm has valid import specifiers', () => {
+            const dts = listDts(esmRoot);
+            expect(dts.length, 'should find .d.ts files under build/esm').toBeGreaterThan(0);
+
+            const offenders = collectDtsImportOffenders(dts);
+
+            expect(
+                offenders,
+                'invalid import specifiers found:\n' +
+                    offenders
+                        .map((o) => `  ${relative(root, o.file)}: '${o.spec}' — ${o.reason}`)
+                        .join('\n'),
+            ).toEqual([]);
+        });
+    });
+
+    describe('require-shim type surface', () => {
+        // Previous revisions declared `export const dynrequire: NodeRequire`,
+        // which leaked an ambient type from @types/node into published .d.ts
+        // — consumers without @types/node would hit TS2304 under
+        // skipLibCheck: false.
+        it('does not leak NodeRequire ambient type', () => {
+            for (const fmt of ['esm', 'cjs'] as const) {
+                const p = resolve(root, `build/${fmt}/plugin/require-shim.d.ts`);
+                const src = readFileSync(p, 'utf8');
+                expect(src, `${fmt} shim must not reference NodeRequire ambient`).not.toMatch(
+                    /\bNodeRequire\b/,
+                );
+            }
+        });
+    });
+
+    describe('require-shim alias wiring', () => {
+        // The esbuild onResolve plugin rewrites `./require-shim` at build time.
+        // If that ever fails silently, the stub's fallback throw will ship in
+        // the final bundle and plugins will crash at runtime. Cheap gate.
+        it('built plugin bundles do not contain the unapplied-stub error', () => {
+            for (const p of [esmEntry, cjsEntry]) {
+                const src = readFileSync(p, 'utf8');
+                expect(src, `${relative(root, p)} must not ship the fallback throw`).not.toContain(
+                    'require-shim: alias was not applied during build',
+                );
+            }
+        });
+    });
+
+    describe('react subpath bundles', () => {
+        it('ESM bundle has top-level export statements and declared names', () => {
+            const src = readFileSync(esmReactEntry, 'utf8');
+            expect(src).toMatch(/^export\b/m);
+            for (const name of REACT_EXPECTED_NAMES) {
+                expect(src, `ESM bundle must export "${name}"`).toContain(name);
+            }
+        });
+
+        it('CJS bundle uses module.exports / exports and declared names', () => {
+            const src = readFileSync(cjsReactEntry, 'utf8');
+            expect(src).toMatch(/\b(?:module\.exports|exports\.)\b/);
+            for (const name of REACT_EXPECTED_NAMES) {
+                expect(src, `CJS bundle must expose "${name}"`).toContain(name);
+            }
+        });
+    });
+
+    describe('utils subpath bundles', () => {
+        it('ESM bundle is parseable ESM and contains declared names', () => {
+            const src = readFileSync(esmUtilsEntry, 'utf8');
+            // utils is minified; match a bare `export {…}` anywhere.
+            expect(src).toMatch(/\bexport\s*\{/);
+            for (const name of UTILS_EXPECTED_NAMES) {
+                expect(src, `ESM bundle must export "${name}"`).toContain(name);
+            }
+        });
+
+        it('CJS bundle uses module.exports / exports and contains declared names', () => {
+            const src = readFileSync(cjsUtilsEntry, 'utf8');
+            expect(src).toMatch(/\b(?:module\.exports|exports\.)\b/);
+            for (const name of UTILS_EXPECTED_NAMES) {
+                expect(src, `CJS bundle must expose "${name}"`).toContain(name);
+            }
+        });
+    });
+
+    describe('runtime bundle (classic browser script)', () => {
+        it('has no top-level ESM export or CJS module.exports', () => {
+            const src = readFileSync(runtimeBundle, 'utf8');
+
+            expect(src).not.toMatch(/^export\b/m);
+            expect(src).not.toMatch(/\bmodule\.exports\b/);
+        });
+
+        it('parses as a classic script (IIFE-style)', () => {
+            const src = readFileSync(runtimeBundle, 'utf8');
+            expect(() => new vm.Script(src)).not.toThrow();
+        });
+    });
+
+    describe('bundle:true end-to-end (regression #1 + #2)', () => {
+        it('ESM plugin copies runtime file from disk without __dirname crash', async () => {
+            const mod = await import(pathToFileURL(esmEntry).href);
+            const destRoot = mkdtempSync(join(tmpdir(), 'htmlext-esm-'));
+            const runtimeJsPath = '_assets/html-extension.js';
+
+            const plugin = mod.transform({
+                bundle: true,
+                runtimeJsPath,
+                embeddingMode: 'srcdoc',
+                isolatedSandboxHost: '',
+            });
+
+            expect(() =>
+                plugin.collect('::: html\n<div>ok</div>\n:::\n', {destRoot}),
+            ).not.toThrow();
+
+            const copied = join(destRoot, runtimeJsPath);
+            expect(existsSync(copied)).toBe(true);
+            const contents = readFileSync(copied, 'utf8');
+            expect(contents).not.toMatch(/^export\b/m);
+            expect(contents).not.toMatch(/\bmodule\.exports\b/);
+        });
+
+        it('CJS plugin copies runtime file with the same contract', () => {
+            const destRoot = mkdtempSync(join(tmpdir(), 'htmlext-cjs-'));
+            const runtimeJsPath = '_assets/html-extension.js';
+            const plugin = req(cjsEntry).transform({
+                bundle: true,
+                runtimeJsPath,
+                embeddingMode: 'srcdoc',
+                isolatedSandboxHost: '',
+            });
+
+            plugin.collect('::: html\n<div>ok</div>\n:::\n', {destRoot});
+
+            expect(existsSync(join(destRoot, runtimeJsPath))).toBe(true);
+            expect(readdirSync(destRoot)).toContain('_assets');
+        });
+    });
+
+    describe('package.json metadata', () => {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+
+        it('declares runtime as side-effectful (regression #4)', () => {
+            expect(Array.isArray(pkg.sideEffects)).toBe(true);
+            expect(pkg.sideEffects).toContain('./build/runtime/index.js');
+        });
+
+        it('runtime export resolves to the IIFE bundle, not dual ESM/CJS', () => {
+            expect(pkg.exports['./runtime'].default).toBe('./build/runtime/index.js');
+            expect(pkg.exports['./runtime'].import).toBeUndefined();
+            expect(pkg.exports['./runtime'].require).toBeUndefined();
+        });
+
+        // The `./runtime` subpath exports deprecated (TS-only) types that
+        // remain available during the deprecation window. The IIFE bundle is
+        // still the sole runtime target, so import/require must not be set —
+        // only the types hint for existing TS consumers.
+        it('advertises deprecated types for ./runtime without an ESM/CJS split', () => {
+            expect(pkg.exports['./runtime'].types).toBe('./build/esm/runtime/index.d.ts');
+            expect(pkg.typesVersions?.['*']?.runtime).toEqual(['./build/esm/runtime/index.d.ts']);
+        });
+
+        it('declares engines.node baseline for ESM support', () => {
+            expect(pkg.engines?.node).toBeDefined();
+        });
+    });
+
+    describe('per-format virtual package.json', () => {
+        // Bundlers treat build/{esm,cjs}/ as nested packages via these files;
+        // sideEffects: false is needed so consumers can tree-shake plugin/
+        // react/ utils/. The root sideEffects array keeps runtime live.
+        it('both formats declare "type" and sideEffects: false', () => {
+            for (const fmt of ['esm', 'cjs'] as const) {
+                const raw = readFileSync(resolve(root, `build/${fmt}/package.json`), 'utf8');
+                const pkg = JSON.parse(raw);
+                expect(pkg.type, `build/${fmt}/package.json must set "type"`).toBe(
+                    fmt === 'esm' ? 'module' : 'commonjs',
+                );
+                expect(
+                    pkg.sideEffects,
+                    `build/${fmt}/package.json must declare sideEffects: false`,
+                ).toBe(false);
+            }
+        });
+
+        it('root package.json keeps runtime in sideEffects array', () => {
+            const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+            expect(pkg.sideEffects).toContain('./build/runtime/index.js');
+        });
+    });
+
+    describe('CJS .d.ts contract', () => {
+        // CJS .d.ts doesn't need `.js` rewriting (tsc with moduleResolution:
+        // Node emits without extensions for `require()`-flavored resolution),
+        // but it should still be free of self-references / broken bare deep
+        // imports that are tested elsewhere.
+        it('has no self-reference imports', () => {
+            const dts = listDts(cjsRoot);
+            const re = /(?:\bfrom\s*|\bimport\s*\(\s*)(['"])([^'"]+)\1/g;
+            const offenders: string[] = [];
+            for (const file of dts) {
+                const src = readFileSync(file, 'utf8');
+                for (const m of src.matchAll(re)) {
+                    if (m[2] === '.' || m[2] === '..') {
+                        offenders.push(`${relative(root, file)}: '${m[2]}'`);
+                    }
+                }
+            }
+            expect(offenders, `self-references found:\n${offenders.join('\n')}`).toEqual([]);
+        });
+    });
+});

--- a/test/plugin.spec.ts
+++ b/test/plugin.spec.ts
@@ -2,6 +2,7 @@ import MarkdownIt from 'markdown-it';
 import dd from 'ts-dedent';
 import {describe, expect, it} from 'vitest';
 
+import {dynrequire} from '../src/plugin/require-shim';
 import {type PluginOptions, transform as htmlTransform} from '../src/plugin';
 
 function html(text: string, opts?: Partial<PluginOptions>) {
@@ -179,5 +180,11 @@ describe('HTML extension – plugin default sanitize', () => {
                 {embeddingMode: 'srcdoc'},
             ),
         ).toMatchSnapshot();
+    });
+});
+
+describe('require-shim stub', () => {
+    it('throws when alias was not applied during build', () => {
+        expect(() => dynrequire('any')).toThrow('require-shim: alias was not applied during build');
     });
 });

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.publish.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "./build/cjs"
+  },
+  "exclude": ["src/**/*.esm.ts"]
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.publish.json",
+  "compilerOptions": {
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "outDir": "./build/esm"
+  },
+  "exclude": ["src/**/*.cjs.ts"]
+}


### PR DESCRIPTION
Publish `@diplodoc/html-extension` as a dual ESM/CJS package so native-ESM consumers can import parse5 v8 (ESM-only), while CJS consumers keep working through `require()`.

## Core changes

- **Dual-publish** via nested conditional `exports`: `build/esm/**` + `build/cjs/**`, each with a virtual `package.json` carrying the matching `"type"` field.
- **parse5** is bundled into the CJS plugin (ESM-only, can't be `require()`'d); kept external in ESM.
- **Runtime** stays a single IIFE — excluded from the dual-build cycle, consumed as `<script src>`.
- **require-shim** switched per format via esbuild `onResolve`: ESM → `createRequire(import.meta.url)`, CJS → native `require`. Replaces the old `eval("require(...)")`.
- **Typed default export**: `export interface HtmlExtensionNamespace` in `plugin/index.ts` prevents tsc from emitting `import(".").*` self-references in `.d.ts`.
- **`fix-esm-dts.mjs`** extended: filesystem-aware `existsSync` resolution (directory imports → `/index.js`), `import("…")` dynamic forms, whitelist for `@diplodoc/transform/lib/*` bare deep-imports.

## Secondary

- `test/built-bundles.spec.ts` — 23 tests covering the full `build/esm/**/*.d.ts` tree; excluded from `test:watch` / `test:coverage` (require a prior build).
- New CI workflow `tests-built.yml` (local, not from scaffolding).
- `DynRequire` local generic replaces ambient `NodeRequire` in shim types — removes implicit `@types/node` from the published type surface.
- `./runtime` types restored with `@deprecated` on `HtmlController` and re-exports.
- `engines.node` aligned with CI baseline (`>=22`).