### PR TITLE
fix: align parse5 with transform

### DIFF
--- a/esbuild/build.mjs
+++ b/esbuild/build.mjs
@@ -47,15 +47,7 @@ build({
     entryPoints: ['src/plugin/index.ts'],
     outfile: 'build/plugin/index.js',
     platform: 'node',
-    // parse5 is ESM-only (v8+), so we bundle it into the CJS output instead of
-    // leaving it as an external require() that would break Jest and other CJS consumers.
-    // All other node_modules remain external as before.
-    external: [
-        '@diplodoc/directive',
-        '@diplodoc/transform',
-        '@diplodoc/transform/*',
-        'markdown-it',
-    ],
+    packages: 'external',
     define: {
         PACKAGE: JSON.stringify(pkg.name),
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@diplodoc/directive": "^0.3.3",
-        "parse5": "^8.0.0"
+        "parse5": "^7.3.0"
       },
       "devDependencies": {
         "@craftamap/esbuild-plugin-html": "^0.7.0",
@@ -4004,32 +4004,6 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
         "entities": "^7.0.1"
-      }
-    },
-    "node_modules/cheerio/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/cheerio/node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -9259,10 +9233,9 @@
       "license": "MIT"
     },
     "node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "license": "MIT",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -9284,32 +9257,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/parse5-parser-stream": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
@@ -9318,32 +9265,6 @@
       "license": "MIT",
       "dependencies": {
         "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-parser-stream/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/parse5-parser-stream/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -114,6 +114,6 @@
   },
   "dependencies": {
     "@diplodoc/directive": "^0.3.3",
-    "parse5": "^8.0.0"
+    "parse5": "^7.3.0"
   }
 }


### PR DESCRIPTION
## Summary

- align the direct `parse5` dependency with the `parse5@7` line already used by `@diplodoc/transform`
- regenerate `package-lock.json` after the dependency change
- revert the temporary esbuild workaround that was introduced specifically for ESM-only `parse5@8`

## Why

`@diplodoc/html-extension` currently installs `parse5@8`, while `@diplodoc/transform` still brings `parse5@7` transitively via `cheerio`.
That leaves downstream consumers with two major versions of the same HTML parser in one dependency tree.

The sanitizer code in `html-extension` only relies on `parseFragment`, `serialize`, and `DefaultTreeAdapterMap`, which are available in `parse5@7` as well.
So aligning `html-extension` back to `parse5@7` removes the version skew without changing the sanitizer logic.

Because `parse5@7` is not ESM-only, we can also go back to `packages: 'external'` in `esbuild/build.mjs` and drop the special CJS bundling workaround that was added for `parse5@8`.

## Validation

- verified that the branch diff only changes `package.json`, `package-lock.json`, and `esbuild/build.mjs`
- regenerated `package-lock.json` with `npm install --package-lock-only --ignore-scripts`
- full repo tests were not run in a local checkout in this workflow
